### PR TITLE
Avoid data loss in stop: Send entries before stop (closes #5 )

### DIFF
--- a/lib/logstash/outputs/monasca_log_api.rb
+++ b/lib/logstash/outputs/monasca_log_api.rb
@@ -208,6 +208,10 @@ class LogStash::Outputs::MonascaLogApi < LogStash::Outputs::Base
   end
 
   def stop_time_check
+    #ensure that entries buffered in queue will be  handled before stop
+    @mutex.synchronize do
+      send_logs
+    end
     @time_thread.kill() if @time_thread
     @logger.info('Stopped time_check thread')
   end


### PR DESCRIPTION
Ensure that entries in internal queue of logstash have been sent before
monasca log-agent stops.