### PR TITLE
update dependency to 7.x in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This module is a logstash-output-plugin for the Monasca Log Api.
 
-Compatible logstash version: [Logstash 2.3.4](https://download.elastic.co/logstash/logstash/logstash-2.3.4.tar.gz)
+Compatible logstash version: [Logstash 7.x](https://www.elastic.co/downloads/logstash)
 
 ## Get latest stable version
 https://rubygems.org/gems/logstash-output-monasca_log_api


### PR DESCRIPTION
the .gemspec specifies a dependency on `logstash-core` `>= 7.0`:

> ~~~
>   s.add_runtime_dependency 'logstash-core', '>= 7.0'
> ~~~
> -- [logstash-output-monasca_log_api.gemspec@v2.0.0:22](https://github.com/logstash-plugins/logstash-output-monasca_log_api/blob/v2.0.0/logstash-output-monasca_log_api.gemspec#L22)