### PR TITLE
Monasca-log-agent fails to start if there is not connection to keystone

### DIFF
--- a/lib/logstash/outputs/keystone/token.rb
+++ b/lib/logstash/outputs/keystone/token.rb
@@ -25,11 +25,29 @@ module LogStash::Outputs
       attr_accessor :id, :expires_at, :keystone_client
 
       def request_new_token(username, user_domain_name, password, project_name, project_domain_name)
-        token = @keystone_client
-          .authenticate(username, user_domain_name, password, project_name, project_domain_name)
-        set_token(token[:token], token[:expires_at])
+        attempt = 0
+        begin
+          @logger.info("Connecting to keystone, attempt no. #{attempt}")
+          token = @keystone_client
+                      .authenticate(username, user_domain_name, password, project_name, project_domain_name)
+          set_token(token[:token], token[:expires_at])
+        rescue => e
+          attempt += 1
+          sleep_for = get_sleep_time(attempt)
+          @logger.error("Sending event to keystone threw exception, "\
+                        "will sleep for #{sleep_for} seconds.",
+                        :exceptionew => e)
+
+          Stud.stoppable_sleep(sleep_for)
+          retry
+        end
         @logger.info('New token requested')
         @logger.debug("token=#{@id}, expire_at=#{@expires_at}")
+      end
+
+      def get_sleep_time(attempt)
+        sleep_for = attempt**2
+        sleep_for <= 60 ? sleep_for : 60
       end
 
       def set_token(id, expires_at)

--- a/logstash-output-monasca_log_api.gemspec
+++ b/logstash-output-monasca_log_api.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-output-monasca_log_api'
-  s.version         = '1.0.4'
+  s.version         = '1.0.5'
   s.licenses = ['Apache-2.0']
   s.summary = 'This gem is a logstash output plugin to connect via http to monasca-log-api.'
   s.description = 'This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program'


### PR DESCRIPTION
The purpose of this commit is to provide mechanism for monasca-log-agent
to wait for keystone service for determined amount of times instead of
failing at first try.